### PR TITLE
Remove entry menu and enable direct chat in both widget variants

### DIFF
--- a/src/components/ChatBody.tsx
+++ b/src/components/ChatBody.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useRef } from 'react';
 import { useMemo, useState } from 'react';
-import type { EntryContext, EntryGoal, InputRequest, Message, QuickReplyAction, QuickReplyOption } from '../types';
+import type { InputRequest, Message, QuickReplyAction, QuickReplyOption } from '../types';
 import { BotMessage } from './Message/BotMessage';
 import { UserMessage } from './Message/UserMessage';
 import { ThinkingIndicator } from './Message/ThinkingIndicator';
-import { EntryFlow } from './EntryFlow/EntryFlow';
 
 export interface QuickReply {
   label: string;
@@ -20,10 +19,6 @@ interface ChatBodyProps {
   quickReplies: QuickReply[];
   contextualQuickReplies?: QuickReplyOption[];
   inputRequest?: InputRequest | null;
-  entryContext: EntryContext;
-  isEntryComplete: boolean;
-  onGoalSelect: (goal: EntryGoal) => void;
-  onStartEntryFlow: () => void;
   onQuickReply: (reply: QuickReplyOption) => void;
   onSubmitInputRequest: (payloadText: string) => void;
 }
@@ -205,10 +200,6 @@ export const ChatBody: React.FC<ChatBodyProps> = ({
   quickReplies,
   contextualQuickReplies = [],
   inputRequest,
-  entryContext,
-  isEntryComplete,
-  onGoalSelect,
-  onStartEntryFlow,
   onQuickReply,
   onSubmitInputRequest,
 }) => {
@@ -221,14 +212,7 @@ export const ChatBody: React.FC<ChatBodyProps> = ({
   return (
     <div className="chat-body">
       {initialGreeting}
-      {messages.length === 0 && !isEntryComplete && (
-        <EntryFlow
-          entryContext={entryContext}
-          onGoalSelect={onGoalSelect}
-          onStart={onStartEntryFlow}
-        />
-      )}
-      {messages.length === 0 && isEntryComplete && quickReplies.length > 0 && (
+      {messages.length === 0 && quickReplies.length > 0 && (
         <div className="button-group">
           {quickReplies.map((reply, i) => (
             <button

--- a/src/components/ChatWidget/ChatWidget.tsx
+++ b/src/components/ChatWidget/ChatWidget.tsx
@@ -150,8 +150,6 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ config, widgetId, onPlan
     isEntryComplete,
     isThinking,
     thinkingText,
-    setEntryGoal,
-    startEntryFlow,
     sendMessage,
     handleQuickReply,
     addBotMessage,
@@ -580,8 +578,6 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ config, widgetId, onPlan
   };
 
   const handleSend = (text: string) => sendMessage(text);
-  const inputLockedByEntryFlow = messages.length === 0 && !isEntryComplete;
-
   const quickReplies: QuickReply[] = isEntryComplete && entryContext.audiencePath
     ? getPromptPack(config.pageContext, entryContext.audiencePath)
     : getDefaultPromptPack(config.pageContext);
@@ -614,18 +610,14 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ config, widgetId, onPlan
                   quickReplies={quickReplies}
                   contextualQuickReplies={activeQuickReplies}
                   inputRequest={activeInputRequest}
-                  entryContext={entryContext}
-                  isEntryComplete={isEntryComplete}
-                  onGoalSelect={setEntryGoal}
-                  onStartEntryFlow={startEntryFlow}
                   onQuickReply={handleQuickReply}
                   onSubmitInputRequest={handleSend}
                 />
                 <ChatFooter
                   onSend={handleSend}
-                  disabled={isThinking || inputLockedByEntryFlow}
+                  disabled={isThinking}
                   conversationId={conversationId}
-                  placeholder={inputLockedByEntryFlow ? 'Bitte zuerst Ziel und Zielgruppe auswählen.' : 'Stelle deine Frage...'}
+                  placeholder={'Stelle deine Frage...'}
                 />
               </div>
               {children}
@@ -641,23 +633,17 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ config, widgetId, onPlan
                 quickReplies={quickReplies}
                 contextualQuickReplies={activeQuickReplies}
                 inputRequest={activeInputRequest}
-                entryContext={entryContext}
-                isEntryComplete={isEntryComplete}
-                onGoalSelect={setEntryGoal}
-                onStartEntryFlow={startEntryFlow}
                 onQuickReply={handleQuickReply}
                 onSubmitInputRequest={handleSend}
               />
               <ChatFooter
                 onSend={handleSend}
-                disabled={isThinking || inputLockedByEntryFlow || isLiveMode || isLiveConnecting}
+                disabled={isThinking || isLiveMode || isLiveConnecting}
                 conversationId={conversationId}
                 placeholder={
-                  inputLockedByEntryFlow
-                    ? 'Bitte zuerst Ziel und Zielgruppe auswählen.'
-                    : isLiveMode
-                      ? 'Live-Modus aktiv. Sprich mit dem Chatbot.'
-                      : 'Stelle deine Frage...'
+                  isLiveMode
+                    ? 'Live-Modus aktiv. Sprich mit dem Chatbot.'
+                    : 'Stelle deine Frage...'
                 }
                 showLiveButton
                 isLiveMode={isLiveMode}


### PR DESCRIPTION
### Motivation
- Customers should be able to start chatting immediately without first selecting an entry goal. 
- The entry selection UI and input lock previously prevented direct interaction until a goal and audience were chosen.

### Description
- Removed the `EntryFlow` render path from `ChatBody` and deleted the `EntryFlow` import and related entry props so quick-replies are shown immediately when there are no messages (`src/components/ChatBody.tsx`).
- Removed entry-flow locking from the widget so the footer input is enabled by default and placeholders are simplified (`src/components/ChatWidget/ChatWidget.tsx`).
- Dropped unused `setEntryGoal`/`startEntryFlow` props passed into `ChatBody` from the widget and simplified the quick-reply selection flow to preserve starter quick-replies when no messages exist.

### Testing
- Ran `npm run build`, which failed in this environment due to missing React/TypeScript dependencies (pre-existing environment issue) and not because of the introduced changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f319d9400483249868e5236bea6a2a)