### PR TITLE
Move context ID from footer to bot action row info icon

### DIFF
--- a/src/components/ChatBody.tsx
+++ b/src/components/ChatBody.tsx
@@ -21,6 +21,7 @@ interface ChatBodyProps {
   inputRequest?: InputRequest | null;
   onQuickReply: (reply: QuickReplyOption) => void;
   onSubmitInputRequest: (payloadText: string) => void;
+  conversationId?: string | null;
 }
 
 function FormSketch({ form }: { form?: InputRequest['form'] }) {
@@ -202,6 +203,7 @@ export const ChatBody: React.FC<ChatBodyProps> = ({
   inputRequest,
   onQuickReply,
   onSubmitInputRequest,
+  conversationId,
 }) => {
   const bottomRef = useRef<HTMLDivElement>(null);
 
@@ -231,7 +233,7 @@ export const ChatBody: React.FC<ChatBodyProps> = ({
       )}
       {messages.map((message) =>
         message.role === 'bot' ? (
-          <BotMessage key={message.id} message={message} />
+          <BotMessage key={message.id} message={message} conversationId={conversationId} />
         ) : (
           <UserMessage key={message.id} message={message} />
         )

--- a/src/components/ChatFooter.tsx
+++ b/src/components/ChatFooter.tsx
@@ -3,7 +3,6 @@ import React, { useRef, useCallback } from 'react';
 interface ChatFooterProps {
   onSend: (text: string) => void;
   disabled?: boolean;
-  conversationId?: string | null;
   placeholder?: string;
   showLiveButton?: boolean;
   isLiveMode?: boolean;
@@ -14,7 +13,6 @@ interface ChatFooterProps {
 export const ChatFooter: React.FC<ChatFooterProps> = ({
   onSend,
   disabled,
-  conversationId,
   placeholder = 'Stelle deine Frage...',
   showLiveButton = false,
   isLiveMode = false,
@@ -78,9 +76,6 @@ export const ChatFooter: React.FC<ChatFooterProps> = ({
         {showLiveButton && liveStatusText && (
           <span className="live-status" role="status" aria-live="polite">{liveStatusText}</span>
         )}
-        <span className="conversation-id">
-          {conversationId ? `Kontext-ID: ${conversationId}` : 'Kontext-ID: –'}
-        </span>
       </div>
     </div>
   );

--- a/src/components/ChatWidget/ChatWidget.tsx
+++ b/src/components/ChatWidget/ChatWidget.tsx
@@ -612,11 +612,11 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ config, widgetId, onPlan
                   inputRequest={activeInputRequest}
                   onQuickReply={handleQuickReply}
                   onSubmitInputRequest={handleSend}
+                  conversationId={conversationId}
                 />
                 <ChatFooter
                   onSend={handleSend}
                   disabled={isThinking}
-                  conversationId={conversationId}
                   placeholder={'Stelle deine Frage...'}
                 />
               </div>
@@ -635,11 +635,11 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ config, widgetId, onPlan
                 inputRequest={activeInputRequest}
                 onQuickReply={handleQuickReply}
                 onSubmitInputRequest={handleSend}
+                conversationId={conversationId}
               />
               <ChatFooter
                 onSend={handleSend}
                 disabled={isThinking || isLiveMode || isLiveConnecting}
-                conversationId={conversationId}
                 placeholder={
                   isLiveMode
                     ? 'Live-Modus aktiv. Sprich mit dem Chatbot.'

--- a/src/components/Message/BotMessage.tsx
+++ b/src/components/Message/BotMessage.tsx
@@ -8,6 +8,7 @@ const BASE_URL = import.meta.env.BASE_URL;
 
 interface BotMessageProps {
   message: Message;
+  conversationId?: string | null;
 }
 
 const IconThumbUp = () => (
@@ -45,7 +46,7 @@ const IconSpeak = () => (
   </svg>
 );
 
-export const BotMessage: React.FC<BotMessageProps> = ({ message }) => {
+export const BotMessage: React.FC<BotMessageProps> = ({ message, conversationId }) => {
   const [thumbState, setThumbState] = useState<'up' | 'down' | null>(null);
   const [copied, setCopied] = useState(false);
   const [isSpeaking, setIsSpeaking] = useState(false);
@@ -131,6 +132,14 @@ export const BotMessage: React.FC<BotMessageProps> = ({ message }) => {
             aria-label="Vorlesen"
           >
             <IconSpeak />
+          </button>
+          <button
+            className="info-btn"
+            title={conversationId ? `Kontext-ID: ${conversationId}` : 'Keine Kontext-ID verfügbar'}
+            aria-label={conversationId ? `Kontext-ID: ${conversationId}` : 'Keine Kontext-ID verfügbar'}
+            type="button"
+          >
+            i
           </button>
           <span
             className="meta-brand"

--- a/src/styles/classic.css
+++ b/src/styles/classic.css
@@ -256,7 +256,8 @@
 
 .thumb-btn,
 .copy-btn,
-.speak-btn {
+.speak-btn,
+.info-btn {
   background: none;
   border: none;
   cursor: pointer;
@@ -269,10 +270,25 @@
 }
 .thumb-btn:hover,
 .copy-btn:hover,
-.speak-btn:hover { color: var(--primary-red); }
+.speak-btn:hover,
+.info-btn:hover { color: var(--primary-red); }
 
 .thumb-btn.active { color: var(--primary-red); }
 .speak-btn.active { color: var(--primary-red); }
+
+.info-btn {
+  font-size: 11px;
+  font-weight: 700;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  width: 14px;
+  height: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  line-height: 1;
+}
 
 .meta-time {
   font-size: 11px;
@@ -643,12 +659,6 @@
   margin-top: 2px;
   font-size: 11px;
   color: #7b7b7b;
-  text-align: center;
-}
-.footer-tools .conversation-id {
-  margin-top: 2px;
-  font-size: 11px;
-  color: #999;
   text-align: center;
 }
 


### PR DESCRIPTION
### Motivation
- Die Kontext-ID soll nicht mehr unten im Widget dupliziert angezeigt werden, sondern näher bei den Bot-Nachrichten verfügbar sein, damit Nutzer sie leichter finden können.
- Ein kleines Info‑Icon in der Aktionsleiste neben dem Lautsprecher ist ein kompakter, nicht‑störender Ort für diese Information.

### Description
- Ergänzt ein kleines `i` Info‑Button in der Bot‑Message‑Aktionszeile, das per `title`/`aria-label` die aktuelle `conversationId` anzeigt und einen Fallbacktext liefert, wenn keine ID vorhanden ist.
- Die `conversationId` wird nun von `ChatWidget` über `ChatBody` an `BotMessage` weitergereicht (`ChatWidget` → `ChatBody` → `BotMessage`).
- Die Anzeige der Kontext‑ID im Footer wurde entfernt und die zugehörige Prop/Markup aus `ChatFooter` gestrichen.
- Stile für das neue `info-btn` wurden in `src/styles/classic.css` ergänzt und die nicht mehr benötigte `.conversation-id`‑CSS‑Regel entfernt.

### Testing
- Ausgeführt: `npm run build` in der Arbeitsumgebung, der Build schlägt fehl wegen fehlender React/TypeScript-Abhängigkeiten in der Umgebung und nicht wegen der Änderung; daher kein change‑spezifischer Fehler festgestellt (Fehler vorhanden: `Cannot find module 'react'` etc.).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f322bf11708324a2d567a2129f1a7c)