### PR TITLE
Adjust teaser placement for middle-left and middle-right positions

### DIFF
--- a/src/styles/classic.css
+++ b/src/styles/classic.css
@@ -91,10 +91,18 @@
   top: auto; bottom: 100px; left: auto; right: 20px; transform: translateY(0);
 }
 .chat-teaser.pos-middle-left {
-  top: 50%; bottom: auto; left: 20px; right: auto; transform: translateY(-50%);
+  top: 50%;
+  bottom: auto;
+  left: 102px;
+  right: auto;
+  transform: translateY(-50%);
 }
 .chat-teaser.pos-middle-right {
-  top: 50%; bottom: auto; left: auto; right: 20px; transform: translateY(-50%);
+  top: 50%;
+  bottom: auto;
+  left: auto;
+  right: 102px;
+  transform: translateY(-50%);
 }
 
 .chat-teaser.hidden {

--- a/styling.css
+++ b/styling.css
@@ -91,10 +91,18 @@
   top: auto; bottom: 100px; left: auto; right: 20px; transform: translateY(0);
 }
 .chat-teaser.pos-middle-left {
-  top: 50%; bottom: auto; left: 20px; right: auto; transform: translateY(-50%);
+  top: 50%;
+  bottom: auto;
+  left: 102px;
+  right: auto;
+  transform: translateY(-50%);
 }
 .chat-teaser.pos-middle-right {
-  top: 50%; bottom: auto; left: auto; right: 20px; transform: translateY(-50%);
+  top: 50%;
+  bottom: auto;
+  left: auto;
+  right: 102px;
+  transform: translateY(-50%);
 }
 
 .chat-teaser.hidden {


### PR DESCRIPTION
### Motivation
- The teaser popup was positioned behind the widget launcher when the widget is in `middle-left` or `middle-right`, so users could not see or interact with it. 
- The change moves the teaser horizontally so it appears beside the launcher for both middle positions and keeps both stylesheet variants consistent.

### Description
- Updated the `.chat-teaser.pos-middle-left` and `.chat-teaser.pos-middle-right` rules in `src/styles/classic.css` to use `left: 102px` and `right: 102px` respectively. 
- Applied the same updates to the parallel `styling.css` to keep public and source styles in sync. 
- Expanded the compact one-line CSS declarations into multi-line properties for clarity and maintainability.

### Testing
- Verified the updated selectors and offsets with `rg -n "chat-teaser.pos-middle-left|chat-teaser.pos-middle-right|left: 102px|right: 102px" src/styles/classic.css styling.css`, which returned the expected hits. 
- Inspected the modified files with `nl -ba src/styles/classic.css` and `nl -ba styling.css` to confirm the new property values and formatting, with no errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3262b42b88324b1ec5db85f0b9c7b)