### PR TITLE
Fix thinking indicator dots rendering

### DIFF
--- a/src/components/Message/ThinkingIndicator.tsx
+++ b/src/components/Message/ThinkingIndicator.tsx
@@ -15,7 +15,7 @@ export const ThinkingIndicator: React.FC<ThinkingIndicatorProps> = ({ text }) =>
       <div className="thinking-indicator">
         <span className="thinking-text">{text}</span>
         <span className="thinking-dots">
-          <span>.</span><span>.</span><span>.</span>
+          <span aria-hidden="true"></span><span aria-hidden="true"></span><span aria-hidden="true"></span>
         </span>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Remove the literal `.` characters that were rendered alongside the CSS dot bubbles so the thinking indicator no longer appears as a stacked/double punctuation and the decorative spans are correctly hidden from assistive tech (`aria-hidden="true"`).

### Description
- Replaced the three text dots inside `src/components/Message/ThinkingIndicator.tsx` with empty spans that include `aria-hidden="true"`, keeping the existing CSS-based animated dots intact.

### Testing
- No automated tests were executed for this small UI-only markup fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f86a73c6008324bdbfd55b5b2844f4)