### PR TITLE
Fix login modal blur overlay scope to widget bounds

### DIFF
--- a/src/styles/classic.css
+++ b/src/styles/classic.css
@@ -547,7 +547,7 @@
 
 /* Login modal */
 .login-modal-backdrop {
-  position: fixed;
+  position: absolute;
   inset: 0;
   display: flex;
   align-items: center;


### PR DESCRIPTION
### Motivation
- The login modal backdrop used `position: fixed` which caused the backdrop blur to cover the entire page when the widget is embedded, so the blur must be constrained to the widget container.

### Description
- Updated `src/styles/classic.css` to change `.login-modal-backdrop` from `position: fixed` to `position: absolute` so the dim/blur overlay is scoped to the widget bounds while keeping the modal layout unchanged.

### Testing
- Ran `npm run build` which failed in the current environment due to missing `react`/type dependencies (pre-existing setup issue) and not due to this CSS change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f86c5836e88324a57d53f945fce988)