### PR TITLE
Add conditional Login/Logout button using localStorage auth state

### DIFF
--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { clearAuthData, useAuth } from '../hooks/useAuth';
 
 interface ChatHeaderProps {
   onRefresh: () => void;
@@ -7,6 +8,18 @@ interface ChatHeaderProps {
 }
 
 export const ChatHeader: React.FC<ChatHeaderProps> = ({ onRefresh, onClose, onLoginClick }) => {
+  const authData = useAuth();
+  const isLoggedIn = Boolean(authData);
+
+  const handleAuthAction = () => {
+    if (isLoggedIn) {
+      clearAuthData();
+      return;
+    }
+
+    onLoginClick();
+  };
+
   return (
     <div className="chat-header">
       <img
@@ -17,12 +30,12 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({ onRefresh, onClose, onLo
       <div className="header-actions">
         <button
           className="header-login-btn"
-          onClick={onLoginClick}
-          title="Einloggen"
-          aria-label="Einloggen"
+          onClick={handleAuthAction}
+          title={isLoggedIn ? 'Ausloggen' : 'Einloggen'}
+          aria-label={isLoggedIn ? 'Ausloggen' : 'Einloggen'}
           type="button"
         >
-          Login
+          {isLoggedIn ? 'Logout' : 'Login'}
         </button>
         <div className="header-icons">
           <button

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,5 +1,8 @@
 import { useEffect, useState } from 'react';
 
+const AUTH_STORAGE_KEY = 'auth';
+const AUTH_CHANGE_EVENT = 'auth-changed';
+
 export interface AuthProfile {
   company?: string;
   address1?: string;
@@ -29,7 +32,7 @@ export interface AuthData {
  */
 export function getAuthData(): AuthData | null {
   try {
-    const authJson = localStorage.getItem('auth');
+    const authJson = localStorage.getItem(AUTH_STORAGE_KEY);
     if (!authJson) return null;
     return JSON.parse(authJson) as AuthData;
   } catch {
@@ -41,18 +44,32 @@ export function getAuthData(): AuthData | null {
  * React hook to access auth data with reactivity.
  * Re-renders when localStorage changes (if storage event is fired).
  */
+
+
+export function clearAuthData(): void {
+  localStorage.removeItem(AUTH_STORAGE_KEY);
+  window.dispatchEvent(new Event(AUTH_CHANGE_EVENT));
+}
+
 export function useAuth(): AuthData | null {
   const [authData, setAuthData] = useState<AuthData | null>(() => getAuthData());
 
   useEffect(() => {
     const handleStorageChange = (event: StorageEvent) => {
-      if (event.key === 'auth') {
+      if (event.key === AUTH_STORAGE_KEY) {
         setAuthData(getAuthData());
       }
     };
 
+    const handleAuthChange = () => setAuthData(getAuthData());
+
     window.addEventListener('storage', handleStorageChange);
-    return () => window.removeEventListener('storage', handleStorageChange);
+    window.addEventListener(AUTH_CHANGE_EVENT, handleAuthChange);
+
+    return () => {
+      window.removeEventListener('storage', handleStorageChange);
+      window.removeEventListener(AUTH_CHANGE_EVENT, handleAuthChange);
+    };
   }, []);
 
   return authData;


### PR DESCRIPTION
### Motivation
- Das Chat-Header-Widget soll den Login-Button kontextabhängig als Logout anzeigen, wenn ein `auth`-Eintrag im `localStorage` vorhanden ist, und beim Logout den Eintrag entfernen, damit das Widget den neuen Zustand reflektiert.

### Description
- Die Header-Komponente wurde angepasst, so dass sie `useAuth()` verwendet und den Button-Text zwischen `Login` und `Logout` wechselt basierend auf dem Vorhandensein von Auth-Daten.
- Das Klickverhalten des Buttons ruft jetzt `clearAuthData()` auf, wenn der Nutzer eingeloggt ist, und sonst weiterhin die übergebene `onLoginClick`-Callback-Funktion.
- Der Auth-Hook wurde refaktoriert und verwendet nun die Konstante `AUTH_STORAGE_KEY` anstelle des hartkodierten Strings, und eine neue Funktion `clearAuthData()` wurde hinzugefügt, die den `auth`-Key entfernt und ein `auth-changed`-Event dispatcht.
- `useAuth()` lauscht zusätzlich auf ein lokales `auth-changed`-Event neben dem `storage`-Event, damit UI-Änderungen im selben Tab sofort sichtbar werden.

### Testing
- Es wurde `npm run build` ausgeführt und der Build schlägt in dieser Umgebung fehl aufgrund fehlender React/TypeScript-Entwicklungsabhängigkeiten (Fehler wie `Cannot find module 'react'`), wobei das Scheitern nicht durch die vorgenommene Änderung verursacht wurde.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8718a153c832496a48b4bde479278)