### PR TITLE
Add collapsible source disclosure for Woody responses

### DIFF
--- a/src/components/Message/BotMessage.tsx
+++ b/src/components/Message/BotMessage.tsx
@@ -51,6 +51,7 @@ export const BotMessage: React.FC<BotMessageProps> = ({ message, conversationId 
   const [copied, setCopied] = useState(false);
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [showBrandPopup, setShowBrandPopup] = useState(false);
+  const [showSources, setShowSources] = useState(false);
 
   const handleCopy = async () => {
     try {
@@ -91,14 +92,24 @@ export const BotMessage: React.FC<BotMessageProps> = ({ message, conversationId 
       <div className="bot-bubble-col">
         <div className="bubble" dangerouslySetInnerHTML={{ __html: renderMarkdown(message.text) }} />
         {message.sources && message.sources.length > 0 && (
-          <div className="bot-sources">
-            <span className="sources-label">Quellen</span>
-            {message.sources.map((url, i) => (
-              <a key={i} href={url} target="_blank" rel="noopener noreferrer">
-                {url}
-              </a>
-            ))}
-          </div>
+          <details className="bot-sources" open={showSources}>
+            <summary
+              className="sources-summary"
+              onClick={(event) => {
+                event.preventDefault();
+                setShowSources((prev) => !prev);
+              }}
+            >
+              Willst du sehen, wie Woody das herausgefunden hat?
+            </summary>
+            <div className="sources-content">
+              {message.sources.map((url, i) => (
+                <a key={i} href={url} target="_blank" rel="noopener noreferrer">
+                  {url}
+                </a>
+              ))}
+            </div>
+          </details>
         )}
         <div className="bot-meta">
           <button

--- a/src/styles/classic.css
+++ b/src/styles/classic.css
@@ -970,24 +970,45 @@
 
 /* Sources block below bot bubble */
 .bot-sources {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  margin-top: 6px;
-  padding: 8px 10px;
-  background: #f5f5f5;
-  border-left: 3px solid var(--primary-red);
-  border-radius: 0 8px 8px 0;
-  max-width: 100%;
+  margin-top: 8px;
+  width: 100%;
 }
 
-.sources-label {
-  font-size: 11px;
+.sources-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  font-size: 12px;
   font-weight: 600;
-  color: #999;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: 2px;
+  color: #6f6f6f;
+  list-style: none;
+}
+
+.sources-summary::-webkit-details-marker {
+  display: none;
+}
+
+.sources-summary::before {
+  content: '▸';
+  color: #888;
+  font-size: 10px;
+  transition: transform 0.2s ease;
+}
+
+.bot-sources[open] .sources-summary::before {
+  transform: rotate(90deg);
+}
+
+.sources-content {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 8px;
+  padding: 10px 12px;
+  background: #f5f5f5;
+  border-left: 3px solid var(--primary-red);
+  border-radius: 0 10px 10px 0;
 }
 
 .bot-sources a {


### PR DESCRIPTION
### Motivation
- Nutzerwunsch: Quellen im Bot-Output standardmäßig einklappbar anzeigen (ähnlich wie bei Claude) und dabei einen kurzen Einladungstext zeigen. 
- Ziel war, die immer sichtbare Linkliste durch eine kompakte Disclosure/Details-UI zu ersetzen, die zum Stil des Widgets passt.

### Description
- Replaced the static source list in `src/components/Message/BotMessage.tsx` with a collapsible `<details>` panel controlled by a new `showSources` state and a `summary` label. 
- Added the requested default summary text `"Willst du sehen, wie Woody das herausgefunden hat?"` as the clickable disclosure label. 
- Updated `src/styles/classic.css` to add `.sources-summary`, `.sources-content` and disclosure arrow styling so the collapsed/expanded UI matches the widget look. 
- Kept the original source links intact and accessible once the panel is expanded.

### Testing
- Ran `npm run build` in this environment and it failed due to missing baseline TypeScript/React dependencies (errors referencing `react`, `react-dom/client`, `react/jsx-runtime` and related types), which are unrelated to this change and prevent a full build verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f874b843b88324a7c6c138847166ab)