### PR TITLE
Add respin (regenerate) control to bot messages and collapsible sources with UI polish

### DIFF
--- a/src/components/ChatBody.tsx
+++ b/src/components/ChatBody.tsx
@@ -24,6 +24,8 @@ interface ChatBodyProps {
   onQuickReply: (reply: QuickReplyOption) => void;
   onSubmitInputRequest: (payloadText: string) => void;
   conversationId?: string | null;
+  onRespinLastAnswer?: () => void;
+  disableRespin?: boolean;
 }
 
 function FormSketch({ form }: { form?: InputRequest['form'] }) {
@@ -547,6 +549,8 @@ export const ChatBody: React.FC<ChatBodyProps> = ({
   onQuickReply,
   onSubmitInputRequest,
   conversationId,
+  onRespinLastAnswer,
+  disableRespin = false,
 }) => {
   const bottomRef = useRef<HTMLDivElement>(null);
 
@@ -576,7 +580,13 @@ export const ChatBody: React.FC<ChatBodyProps> = ({
       )}
       {messages.map((message) =>
         message.role === 'bot' ? (
-          <BotMessage key={message.id} message={message} conversationId={conversationId} />
+          <BotMessage
+            key={message.id}
+            message={message}
+            conversationId={conversationId}
+            onRespin={onRespinLastAnswer}
+            disableRespin={disableRespin}
+          />
         ) : (
           <UserMessage key={message.id} message={message} />
         )

--- a/src/components/ChatWidget/ChatWidget.tsx
+++ b/src/components/ChatWidget/ChatWidget.tsx
@@ -592,9 +592,14 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ config, widgetId, onPlan
 
   const handleSend = (text: string) => sendMessage(text);
   const handleRespinLastAnswer = useCallback(() => {
-    const lastUserMessage = [...messages].reverse().find((message) => message.role === 'user');
-    if (!lastUserMessage || isThinking) return;
-    sendMessage(lastUserMessage.text);
+    if (isThinking || messages.length < 2) return;
+
+    const lastMessage = messages[messages.length - 1];
+    const previousMessage = messages[messages.length - 2];
+
+    if (lastMessage.role !== 'bot' || previousMessage.role !== 'user') return;
+
+    sendMessage(previousMessage.text);
   }, [messages, isThinking, sendMessage]);
   const quickReplies: QuickReply[] = isEntryComplete && entryContext.audiencePath
     ? getPromptPack(config.pageContext, entryContext.audiencePath)

--- a/src/components/ChatWidget/ChatWidget.tsx
+++ b/src/components/ChatWidget/ChatWidget.tsx
@@ -591,6 +591,11 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ config, widgetId, onPlan
   };
 
   const handleSend = (text: string) => sendMessage(text);
+  const handleRespinLastAnswer = useCallback(() => {
+    const lastUserMessage = [...messages].reverse().find((message) => message.role === 'user');
+    if (!lastUserMessage || isThinking) return;
+    sendMessage(lastUserMessage.text);
+  }, [messages, isThinking, sendMessage]);
   const quickReplies: QuickReply[] = isEntryComplete && entryContext.audiencePath
     ? getPromptPack(config.pageContext, entryContext.audiencePath)
     : getDefaultPromptPack(config.pageContext);
@@ -626,6 +631,8 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ config, widgetId, onPlan
                   onQuickReply={handleQuickReply}
                   onSubmitInputRequest={handleSend}
                   conversationId={conversationId}
+                  onRespinLastAnswer={handleRespinLastAnswer}
+                  disableRespin={isThinking}
                 />
                 <ChatFooter
                   onSend={handleSend}
@@ -649,6 +656,8 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ config, widgetId, onPlan
                 onQuickReply={handleQuickReply}
                 onSubmitInputRequest={handleSend}
                 conversationId={conversationId}
+                onRespinLastAnswer={handleRespinLastAnswer}
+                disableRespin={isThinking}
               />
               <ChatFooter
                 onSend={handleSend}

--- a/src/components/Message/BotMessage.tsx
+++ b/src/components/Message/BotMessage.tsx
@@ -9,6 +9,8 @@ const BASE_URL = import.meta.env.BASE_URL;
 interface BotMessageProps {
   message: Message;
   conversationId?: string | null;
+  onRespin?: () => void;
+  disableRespin?: boolean;
 }
 
 const IconThumbUp = () => (
@@ -46,11 +48,12 @@ const IconSpeak = () => (
   </svg>
 );
 
-export const BotMessage: React.FC<BotMessageProps> = ({ message, conversationId }) => {
+export const BotMessage: React.FC<BotMessageProps> = ({ message, conversationId, onRespin, disableRespin = false }) => {
   const [thumbState, setThumbState] = useState<'up' | 'down' | null>(null);
   const [copied, setCopied] = useState(false);
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [showBrandPopup, setShowBrandPopup] = useState(false);
+  const [showSources, setShowSources] = useState(false);
 
   const handleCopy = async () => {
     try {
@@ -89,17 +92,27 @@ export const BotMessage: React.FC<BotMessageProps> = ({ message, conversationId 
         <img src={`${BASE_URL}woody.png`} alt="Woody" />
       </div>
       <div className="bot-bubble-col">
-        <div className="bubble" dangerouslySetInnerHTML={{ __html: renderMarkdown(message.text) }} />
         {message.sources && message.sources.length > 0 && (
-          <div className="bot-sources">
-            <span className="sources-label">Quellen</span>
-            {message.sources.map((url, i) => (
-              <a key={i} href={url} target="_blank" rel="noopener noreferrer">
-                {url}
-              </a>
-            ))}
-          </div>
+          <details className="bot-sources" open={showSources}>
+            <summary
+              className="sources-summary"
+              onClick={(event) => {
+                event.preventDefault();
+                setShowSources((prev) => !prev);
+              }}
+            >
+              Willst du sehen, wie Woody das herausgefunden hat?
+            </summary>
+            <div className="sources-content">
+              {message.sources.map((url, i) => (
+                <a key={i} href={url} target="_blank" rel="noopener noreferrer">
+                  {url}
+                </a>
+              ))}
+            </div>
+          </details>
         )}
+        <div className="bubble" dangerouslySetInnerHTML={{ __html: renderMarkdown(message.text) }} />
         <div className="bot-meta">
           <button
             className={`thumb-btn thumb-up${thumbState === 'up' ? ' active' : ''}`}
@@ -132,6 +145,16 @@ export const BotMessage: React.FC<BotMessageProps> = ({ message, conversationId 
             aria-label="Vorlesen"
           >
             <IconSpeak />
+          </button>
+          <button
+            className="respin-btn"
+            onClick={onRespin}
+            title="Neu generieren"
+            aria-label="Neu generieren"
+            type="button"
+            disabled={disableRespin || !onRespin}
+          >
+            ⟳
           </button>
           <button
             className="info-btn"

--- a/src/styles/classic.css
+++ b/src/styles/classic.css
@@ -424,6 +424,7 @@
 .thumb-btn,
 .copy-btn,
 .speak-btn,
+.respin-btn,
 .info-btn {
   background: none;
   border: none;
@@ -439,6 +440,7 @@
 .thumb-btn:hover,
 .copy-btn:hover,
 .speak-btn:hover,
+.respin-btn:hover,
 .info-btn:hover {
   color: var(--primary-red);
 }
@@ -449,6 +451,11 @@
 
 .speak-btn.active {
   color: var(--primary-red);
+}
+
+.respin-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 
 .info-btn {
@@ -970,24 +977,38 @@
 
 /* Sources block below bot bubble */
 .bot-sources {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  margin-top: 6px;
-  padding: 8px 10px;
-  background: #f5f5f5;
-  border-left: 3px solid var(--primary-red);
-  border-radius: 0 8px 8px 0;
-  max-width: 100%;
+  margin-top: 8px;
+  width: 100%;
 }
 
-.sources-label {
-  font-size: 11px;
+.sources-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  font-size: 12px;
   font-weight: 600;
-  color: #999;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: 2px;
+  color: #6f6f6f;
+  list-style: none;
+}
+
+.sources-summary::-webkit-details-marker {
+  display: none;
+}
+
+.sources-summary::marker {
+  content: '';
+}
+
+.sources-content {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 8px;
+  padding: 10px 12px;
+  background: #f5f5f5;
+  border-left: 3px solid var(--primary-red);
+  border-radius: 0 10px 10px 0;
 }
 
 .bot-sources a {
@@ -1162,7 +1183,12 @@
   gap: 5px;
   font-size: 13px;
   font-style: italic;
-  color: #c0c0c0;
+  color: transparent;
+  background: linear-gradient(90deg, #9f9f9f 0%, #cfcfcf 45%, #9f9f9f 100%);
+  background-size: 220% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  animation: thinking-gradient 2.1s linear infinite;
   user-select: none;
 }
 
@@ -1209,5 +1235,14 @@
   50% {
     opacity: 1;
     transform: translateY(-3px);
+  }
+}
+
+@keyframes thinking-gradient {
+  from {
+    background-position: 200% 0;
+  }
+  to {
+    background-position: -20% 0;
   }
 }


### PR DESCRIPTION
### Motivation

- Allow users to quickly regenerate the last bot answer by replaying their previous user message.  
- Make message sources less intrusive by moving them into a toggled/collapsible view.  
- Improve small UI details like the respin button state and the thinking indicator animation for better feedback.

### Description

- Added `onRespinLastAnswer` and `disableRespin` props to `ChatBody` and wired them from `ChatWidget` via a new `handleRespinLastAnswer` callback that re-sends the last user message when appropriate.  
- Extended `BotMessage` to accept `onRespin` and `disableRespin`, added a respin button (`⟳`) that calls `onRespin` and is disabled when `disableRespin` or no handler is provided.  
- Moved `message.sources` into a collapsible `<details>` block with a custom summary and a `showSources` state toggle, and adjusted markup so the sources are shown above the rendered bubble.  
- Updated `classic.css` with styles for the respin button disabled state, new sources block/summary/content styling, and a gradient animated `thinking` text effect.

### Testing

- Ran the test suite with `npm test` (unit tests) and all tests passed.  
- Performed a TypeScript build/typecheck with `npm run build` and it completed without errors.  
- Ran linting with `npm run lint` and automatic checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f874b843b88324a7c6c138847166ab)