### PR TITLE
Add language selector (DE/EN) to widget header

### DIFF
--- a/src/components/ChatFooter.tsx
+++ b/src/components/ChatFooter.tsx
@@ -1,4 +1,6 @@
 import React, { useRef, useCallback } from 'react';
+import type { WidgetLanguage } from '../config/i18n';
+import { UI_COPY } from '../config/i18n';
 
 interface ChatFooterProps {
   onSend: (text: string) => void;
@@ -8,18 +10,21 @@ interface ChatFooterProps {
   isLiveMode?: boolean;
   onToggleLiveMode?: () => void;
   liveStatusText?: string | null;
+  language?: WidgetLanguage;
 }
 
 export const ChatFooter: React.FC<ChatFooterProps> = ({
   onSend,
   disabled,
-  placeholder = 'Stelle deine Frage...',
+  placeholder,
+  language = 'de',
   showLiveButton = false,
   isLiveMode = false,
   onToggleLiveMode,
   liveStatusText,
 }) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const copy = UI_COPY[language];
 
   const handleSend = useCallback(() => {
     const text = textareaRef.current?.value.trim();
@@ -49,13 +54,13 @@ export const ChatFooter: React.FC<ChatFooterProps> = ({
         <textarea
           ref={textareaRef}
           rows={1}
-          placeholder={placeholder}
+          placeholder={placeholder ?? copy.inputPlaceholder}
           onKeyDown={handleKeyDown}
           onChange={handleInput}
           disabled={disabled}
-          aria-label="Nachricht eingeben"
+          aria-label={copy.inputLabel}
         />
-        <button className="send-btn" onClick={handleSend} disabled={disabled} aria-label="Senden">
+        <button className="send-btn" onClick={handleSend} disabled={disabled} aria-label={copy.sendLabel}>
           ➤
         </button>
         {showLiveButton && (
@@ -72,7 +77,7 @@ export const ChatFooter: React.FC<ChatFooterProps> = ({
         )}
       </div>
       <div className="footer-tools">
-        <span className="branding">KI-Unterstützung kann Fehler machen.</span>
+        <span className="branding">{copy.aiDisclaimer}</span>
         {showLiveButton && liveStatusText && (
           <span className="live-status" role="status" aria-live="polite">{liveStatusText}</span>
         )}

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
 import { clearAuthData, useAuth } from '../hooks/useAuth';
+import type { WidgetLanguage } from '../config/i18n';
+import { UI_COPY } from '../config/i18n';
 
 interface ChatHeaderProps {
   onRefresh: () => void;
   onClose: () => void;
   onLoginClick: () => void;
+  language: WidgetLanguage;
+  onLanguageChange: (language: WidgetLanguage) => void;
 }
 
-export const ChatHeader: React.FC<ChatHeaderProps> = ({ onRefresh, onClose, onLoginClick }) => {
+export const ChatHeader: React.FC<ChatHeaderProps> = ({ onRefresh, onClose, onLoginClick, language, onLanguageChange }) => {
+  const copy = UI_COPY[language];
   const authData = useAuth();
   const isLoggedIn = Boolean(authData);
 
@@ -28,28 +33,37 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({ onRefresh, onClose, onLo
         className="logo-img"
       />
       <div className="header-actions">
+        <select
+          className="header-language-select"
+          value={language}
+          onChange={(event) => onLanguageChange(event.target.value as WidgetLanguage)}
+          aria-label="Language"
+        >
+          <option value="de">Deutsch</option>
+          <option value="en">English</option>
+        </select>
         <button
           className="header-login-btn"
           onClick={handleAuthAction}
-          title={isLoggedIn ? 'Ausloggen' : 'Einloggen'}
-          aria-label={isLoggedIn ? 'Ausloggen' : 'Einloggen'}
+          title={isLoggedIn ? copy.logoutAction : copy.loginAction}
+          aria-label={isLoggedIn ? copy.logoutAction : copy.loginAction}
           type="button"
         >
-          {isLoggedIn ? 'Logout' : 'Login'}
+          {isLoggedIn ? copy.logout : copy.login}
         </button>
         <div className="header-icons">
           <button
             onClick={onRefresh}
-            title="Gespräch neu starten"
-            aria-label="Gespräch neu starten"
+            title={copy.restartConversation}
+            aria-label={copy.restartConversation}
             type="button"
           >
             &#8634;
           </button>
           <button
             onClick={onClose}
-            title="Chat schließen"
-            aria-label="Chat schließen"
+            title={copy.closeChat}
+            aria-label={copy.closeChat}
             type="button"
           >
             &times;

--- a/src/components/ChatToggle.tsx
+++ b/src/components/ChatToggle.tsx
@@ -1,19 +1,23 @@
 import React from 'react';
+import type { WidgetLanguage } from '../config/i18n';
+import { UI_COPY } from '../config/i18n';
 
 const BASE_URL = import.meta.env.BASE_URL;
 
 interface ChatToggleProps {
   onClick: () => void;
   position?: string;
+  language?: WidgetLanguage;
 }
 
-export const ChatToggle: React.FC<ChatToggleProps> = ({ onClick, position = 'bottom-right' }) => {
+export const ChatToggle: React.FC<ChatToggleProps> = ({ onClick, position = 'bottom-right', language = 'de' }) => {
+  const copy = UI_COPY[language];
   return (
     <div
       className={`chat-toggle pos-${position}`}
       onClick={onClick}
       role="button"
-      aria-label="Chat öffnen"
+      aria-label={copy.openChatLabel}
       tabIndex={0}
       onKeyDown={(e) => e.key === 'Enter' && onClick()}
     >

--- a/src/components/ChatWidget/ChatWidget.tsx
+++ b/src/components/ChatWidget/ChatWidget.tsx
@@ -16,6 +16,8 @@ import type { WidgetConfig, ConversationHistoryItem } from '../../types';
 import { getDefaultPromptPack, getPromptPack } from '../../config/promptPacks';
 import { speakText } from '../../utils/speech';
 import { getAuthData } from '../../hooks/useAuth';
+import type { WidgetLanguage } from '../../config/i18n';
+import { UI_COPY } from '../../config/i18n';
 
 const BASE_URL = import.meta.env.BASE_URL;
 
@@ -106,8 +108,9 @@ interface MinimalSpeechRecognition {
   stop: () => void;
 }
 
-function InitialGreeting({ mode }: { mode: 'classic' | 'landscape' }) {
-  const time = new Date().toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+function InitialGreeting({ mode, language }: { mode: 'classic' | 'landscape'; language: WidgetLanguage }) {
+  const copy = UI_COPY[language];
+  const time = new Date().toLocaleTimeString(language === 'de' ? 'de-DE' : 'en-US', { hour: '2-digit', minute: '2-digit' });
   const auth = getAuthData();
   const userName = auth?.user?.name ? ` Hallo ${auth.user.name}!` : '';
 
@@ -116,22 +119,22 @@ function InitialGreeting({ mode }: { mode: 'classic' | 'landscape' }) {
       <div className="bot-icon"><img src={`${BASE_URL}woody.png`} alt="Woody" /></div>
       <div className="bot-bubble-col">
         <div className="bubble">
-          <p>{userName} Willkommen bei megawood&#174;! &#128075;</p>
+          <p>{userName} {copy.greetingWelcome}</p>
           {mode === 'landscape' ? (
             <>
-              <p>Ich bin <b>Handwerker Woody</b>, dein persönlicher KI-Assistent! Du kannst mich alles zu unseren Produkten fragen, oder wir können eine Planung zusammen erstellen.</p>
-              <p>Lass uns gleich mit der Planung beginnen!</p>
+              <p>{copy.greetingLandscapeLine1}</p>
+              <p>{copy.greetingLandscapeLine2}</p>
             </>
           ) : (
             <>
-              <p>Ich bin <b>Woody</b>, die megawood&#174; KI! Du kannst mir alle Fragen zu unseren Produkten stellen.</p>
-              <p>Womit kann ich dir heute helfen?</p>
+              <p>{copy.greetingClassicLine1}</p>
+              <p>{copy.greetingClassicLine2}</p>
             </>
           )}
         </div>
         <div className="bot-meta">
           <span className="meta-time">{time}</span>
-          <span className="meta-brand">Erstellt von megawood KI</span>
+          <span className="meta-brand">{copy.createdBy}</span>
         </div>
       </div>
     </div>
@@ -142,6 +145,7 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ config, widgetId, onPlan
   const [isOpen, setIsOpen] = useState(false);
   const [isLoginOpen, setIsLoginOpen] = useState(false);
   const [isLiveMode, setIsLiveMode] = useState(false);
+  const [language, setLanguage] = useState<WidgetLanguage>('de');
   const [isLiveConnecting, setIsLiveConnecting] = useState(false);
   const [liveStatusText, setLiveStatusText] = useState<string | null>(null);
   const { conversationId, saveConversationId, clearConversation } = useConversation(widgetId);
@@ -609,7 +613,8 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ config, widgetId, onPlan
     ? getPromptPack(config.pageContext, entryContext.audiencePath)
     : getDefaultPromptPack(config.pageContext);
   const posClass = `pos-${config.position}`;
-  const initialGreeting = <InitialGreeting mode={config.mode} />;
+  const copy = UI_COPY[language];
+  const initialGreeting = <InitialGreeting mode={config.mode} language={language} />;
 
   return (
     <>
@@ -622,13 +627,13 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ config, widgetId, onPlan
           onOpen={handleOpen}
         />
       )}
-      {!isOpen && <ChatToggle onClick={handleOpen} position={config.position} />}
+      {!isOpen && <ChatToggle onClick={handleOpen} position={config.position} language={language} />}
       {isOpen && (
         <div className={`chat-container ${config.mode === 'landscape' ? 'landscape-widget' : ''} ${posClass}`}>
           {config.mode === 'landscape' ? (
             <div className="chat-layout">
               <div className="chat-main">
-                <ChatHeader onRefresh={handleRefresh} onClose={handleClose} onLoginClick={handleOpenLogin} />
+                <ChatHeader onRefresh={handleRefresh} onClose={handleClose} onLoginClick={handleOpenLogin} language={language} onLanguageChange={setLanguage} />
                 <ChatBody
                   messages={messages}
                   isThinking={isThinking}
@@ -646,14 +651,15 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ config, widgetId, onPlan
                 <ChatFooter
                   onSend={handleSend}
                   disabled={isThinking}
-                  placeholder={'Stelle deine Frage...'}
+                  placeholder={copy.inputPlaceholder}
+                  language={language}
                 />
               </div>
               {children}
             </div>
           ) : (
             <>
-              <ChatHeader onRefresh={handleRefresh} onClose={handleClose} onLoginClick={handleOpenLogin} />
+              <ChatHeader onRefresh={handleRefresh} onClose={handleClose} onLoginClick={handleOpenLogin} language={language} onLanguageChange={setLanguage} />
               <ChatBody
                 messages={messages}
                 isThinking={isThinking}
@@ -673,13 +679,14 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ config, widgetId, onPlan
                 disabled={isThinking || isLiveMode || isLiveConnecting}
                 placeholder={
                   isLiveMode
-                    ? 'Live-Modus aktiv. Sprich mit dem Chatbot.'
-                    : 'Stelle deine Frage...'
+                    ? language === 'de' ? 'Live-Modus aktiv. Sprich mit dem Chatbot.' : 'Live mode active. Speak to the chatbot.'
+                    : copy.inputPlaceholder
                 }
                 showLiveButton
                 isLiveMode={isLiveMode}
                 onToggleLiveMode={toggleLiveMode}
                 liveStatusText={liveStatusText}
+                language={language}
               />
             </>
           )}

--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -1,0 +1,62 @@
+export type WidgetLanguage = 'de' | 'en';
+
+export interface UiCopy {
+  login: string;
+  logout: string;
+  loginAction: string;
+  logoutAction: string;
+  restartConversation: string;
+  closeChat: string;
+  inputPlaceholder: string;
+  inputLabel: string;
+  sendLabel: string;
+  openChatLabel: string;
+  greetingWelcome: string;
+  greetingClassicLine1: string;
+  greetingClassicLine2: string;
+  greetingLandscapeLine1: string;
+  greetingLandscapeLine2: string;
+  createdBy: string;
+  aiDisclaimer: string;
+}
+
+export const UI_COPY: Record<WidgetLanguage, UiCopy> = {
+  de: {
+    login: 'Login',
+    logout: 'Logout',
+    loginAction: 'Einloggen',
+    logoutAction: 'Ausloggen',
+    restartConversation: 'Gespräch neu starten',
+    closeChat: 'Chat schließen',
+    inputPlaceholder: 'Stelle deine Frage...',
+    inputLabel: 'Nachricht eingeben',
+    sendLabel: 'Senden',
+    openChatLabel: 'Chat öffnen',
+    greetingWelcome: 'Willkommen bei megawood®! 👋',
+    greetingClassicLine1: 'Ich bin Woody, die megawood® KI! Du kannst mir alle Fragen zu unseren Produkten stellen.',
+    greetingClassicLine2: 'Womit kann ich dir heute helfen?',
+    greetingLandscapeLine1: 'Ich bin Handwerker Woody, dein persönlicher KI-Assistent! Du kannst mich alles zu unseren Produkten fragen, oder wir können eine Planung zusammen erstellen.',
+    greetingLandscapeLine2: 'Lass uns gleich mit der Planung beginnen!',
+    createdBy: 'Erstellt von megawood KI',
+    aiDisclaimer: 'KI-Unterstützung kann Fehler machen.',
+  },
+  en: {
+    login: 'Login',
+    logout: 'Logout',
+    loginAction: 'Sign in',
+    logoutAction: 'Sign out',
+    restartConversation: 'Restart conversation',
+    closeChat: 'Close chat',
+    inputPlaceholder: 'Ask your question...',
+    inputLabel: 'Type message',
+    sendLabel: 'Send',
+    openChatLabel: 'Open chat',
+    greetingWelcome: 'Welcome to megawood®! 👋',
+    greetingClassicLine1: 'I am Woody, the megawood® AI! You can ask me anything about our products.',
+    greetingClassicLine2: 'How can I help you today?',
+    greetingLandscapeLine1: 'I am Woody the Craftsman, your personal AI assistant! Ask me anything about our products, or we can create a planning together.',
+    greetingLandscapeLine2: "Let's start planning right away!",
+    createdBy: 'Created by megawood AI',
+    aiDisclaimer: 'AI assistance can make mistakes.',
+  },
+};

--- a/src/styles/classic.css
+++ b/src/styles/classic.css
@@ -341,6 +341,17 @@
   gap: 8px;
 }
 
+
+.header-language-select {
+  border: 1.5px solid var(--primary-red);
+  border-radius: 999px;
+  background: var(--bg-white);
+  color: var(--primary-red);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 6px 10px;
+  cursor: pointer;
+}
 .header-login-btn {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
### Motivation
- Provide a simple language switch in the widget header so users can toggle the widget UI between German and English and see immediate updates to core UI text. 
- Centralize widget UI copy to allow consistent translations for header, footer, toggle and greeting text.

### Description
- Added a new copy module `src/config/i18n.ts` exporting `UI_COPY` and `WidgetLanguage` with `de`/`en` entries for the main UI strings. 
- Extended `ChatHeader` to render a language `<select>` and accept `language` / `onLanguageChange` props so the header can switch languages (`src/components/ChatHeader.tsx`).
- Added language state to `ChatWidget` and wired it into `ChatHeader`, `ChatFooter`, `ChatToggle`, and the initial greeting so labels and placeholders update immediately (`src/components/ChatWidget/ChatWidget.tsx`).
- Made `ChatFooter` and `ChatToggle` use the shared `UI_COPY` for placeholder/ARIA/branding text and added styles for the header select in `src/styles/classic.css`.

### Testing
- Ran `npm run build` to validate the changes; the build failed due to pre-existing TypeScript / dependency issues in the environment (missing React types and many TS errors) which are unrelated to this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a91bf4e48324b248f753e28649b3)