### PR TITLE
Improve bot message footer spacing and icon style consistency

### DIFF
--- a/src/components/Message/BotMessage.tsx
+++ b/src/components/Message/BotMessage.tsx
@@ -40,6 +40,23 @@ const IconCopied = () => (
   </svg>
 );
 
+
+const IconRefresh = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M21 2v6h-6"/>
+    <path d="M3 22v-6h6"/>
+    <path d="M3.51 9a9 9 0 0 1 14.13-3.36L21 8"/>
+    <path d="M20.49 15a9 9 0 0 1-14.13 3.36L3 16"/>
+  </svg>
+);
+
+const IconInfo = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="10"/>
+    <path d="M12 16v-4"/>
+    <path d="M12 8h.01"/>
+  </svg>
+);
 const IconSpeak = () => (
   <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/>
@@ -154,7 +171,7 @@ export const BotMessage: React.FC<BotMessageProps> = ({ message, conversationId,
             type="button"
             disabled={disableRespin || !onRespin}
           >
-            ⟳
+            <IconRefresh />
           </button>
           <button
             className="info-btn"
@@ -162,7 +179,7 @@ export const BotMessage: React.FC<BotMessageProps> = ({ message, conversationId,
             aria-label={conversationId ? `Kontext-ID: ${conversationId}` : 'Keine Kontext-ID verfügbar'}
             type="button"
           >
-            i
+            <IconInfo />
           </button>
           <span
             className="meta-brand"

--- a/src/styles/classic.css
+++ b/src/styles/classic.css
@@ -422,8 +422,9 @@
 
 .bot-meta {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   margin-top: 4px;
   padding-left: 2px;
 }
@@ -446,6 +447,10 @@
   line-height: 1;
   user-select: none;
   transition: color 0.15s;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
 }
 
 .thumb-btn:hover,
@@ -469,31 +474,34 @@
   opacity: 0.5;
 }
 
-.info-btn {
-  font-size: 11px;
-  font-weight: 700;
-  border: 1px solid currentColor;
-  border-radius: 50%;
-  width: 14px;
-  height: 14px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  line-height: 1;
-}
-
-.meta-time {
-  font-size: 11px;
-  color: #aaa;
-}
-
 .meta-brand {
   font-size: 11px;
   color: #bbb;
   cursor: pointer;
   user-select: none;
+  margin-left: 4px;
+  white-space: nowrap;
 }
+
+.meta-time {
+  font-size: 11px;
+  color: #aaa;
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+@media (max-width: 430px) {
+  .meta-brand {
+    flex: 1 0 100%;
+    margin-left: 0;
+    white-space: normal;
+  }
+
+  .meta-time {
+    margin-left: 0;
+  }
+}
+
 
 .meta-brand:hover {
   color: #999;


### PR DESCRIPTION
### Motivation
- The bot message footer was visually cramped on narrow widths and action text like `Neu generieren` and `i` did not match the visual style of the other icon actions.
- The intent is to make the action bar more compact and consistent so the text doesn't overflow or look misaligned.
- Metadata (`Erstellt von …` and the timestamp) should adapt more gracefully on small screens to avoid layout breakage.

### Description
- Replaced the text-based respin/info actions with inline SVG components `IconRefresh` and `IconInfo` in `src/components/Message/BotMessage.tsx` so all actions share the same stroke icon style. 
- Updated the button markup to render `IconRefresh` and `IconInfo` in place of the textual `⟳` and `i` content in `BotMessage`. 
- Adjusted layout and spacing in `src/styles/classic.css` by enabling `flex-wrap` on `.bot-meta`, reducing the gap, making action buttons `display: inline-flex` with `flex: 0 0 auto`, and adding responsive rules for `.meta-brand` and `.meta-time` so brand text can wrap on small screens.

### Testing
- Ran `npm run build`, which failed in this environment due to missing React/TypeScript dependencies (`react` types and `react/jsx-runtime`) unrelated to these UI changes, so the failure is environmental and not caused by this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c88408b8832486ef15a9bc84ae84)