### PR TITLE
Simplify chat header controls for a cleaner top bar

### DIFF
--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -15,6 +15,7 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({ onRefresh, onClose, onLo
   const copy = UI_COPY[language];
   const authData = useAuth();
   const isLoggedIn = Boolean(authData);
+  const nextLanguage: WidgetLanguage = language === 'de' ? 'en' : 'de';
 
   const handleAuthAction = () => {
     if (isLoggedIn) {
@@ -33,23 +34,23 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({ onRefresh, onClose, onLo
         className="logo-img"
       />
       <div className="header-actions">
-        <select
-          className="header-language-select"
-          value={language}
-          onChange={(event) => onLanguageChange(event.target.value as WidgetLanguage)}
-          aria-label="Language"
-        >
-          <option value="de">Deutsch</option>
-          <option value="en">English</option>
-        </select>
         <button
-          className="header-login-btn"
+          className="header-pill-btn"
+          onClick={() => onLanguageChange(nextLanguage)}
+          title={language === 'de' ? 'Switch to English' : 'Auf Deutsch wechseln'}
+          aria-label={language === 'de' ? 'Switch to English' : 'Auf Deutsch wechseln'}
+          type="button"
+        >
+          {language.toUpperCase()}
+        </button>
+        <button
+          className="header-pill-btn"
           onClick={handleAuthAction}
           title={isLoggedIn ? copy.logoutAction : copy.loginAction}
           aria-label={isLoggedIn ? copy.logoutAction : copy.loginAction}
           type="button"
         >
-          {isLoggedIn ? copy.logout : copy.login}
+          {isLoggedIn ? '↪' : '↩'}
         </button>
         <div className="header-icons">
           <button

--- a/src/styles/classic.css
+++ b/src/styles/classic.css
@@ -319,7 +319,7 @@
 
 /* Header */
 .chat-header {
-  padding: 12px 16px;
+  padding: 10px 14px;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -331,7 +331,7 @@
 }
 
 .logo-img {
-  height: 48px;
+  height: 42px;
   object-fit: contain;
 }
 
@@ -342,38 +342,29 @@
 }
 
 
-.header-language-select {
+.header-pill-btn {
+  min-width: 38px;
   border: 1.5px solid var(--primary-red);
   border-radius: 999px;
   background: var(--bg-white);
   color: var(--primary-red);
-  font-size: 12px;
-  font-weight: 600;
+  font-size: 11px;
+  font-weight: 700;
   padding: 6px 10px;
   cursor: pointer;
-}
-.header-login-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 7px 14px;
-  border: 1.5px solid var(--primary-red);
-  border-radius: 999px;
-  background: var(--bg-white);
-  color: var(--primary-red);
-  font-size: 13px;
-  font-weight: 700;
   line-height: 1;
-  cursor: pointer;
   transition: background 0.15s, color 0.15s, transform 0.15s;
 }
 
-.header-login-btn:hover {
+.header-pill-btn:hover {
   background: var(--primary-red);
   color: #fff;
 }
 
-.header-login-btn:active {
+.header-pill-btn:active {
   transform: translateY(1px);
 }
 

--- a/src/styles/landscape.css
+++ b/src/styles/landscape.css
@@ -290,7 +290,7 @@
   white-space: nowrap;
 }
 
-.chat-container.landscape-widget .header-login-btn {
+.chat-container.landscape-widget .header-pill-btn {
   font-size: 12px;
   padding: 6px 12px;
 }


### PR DESCRIPTION
### Motivation
- The top header was visually heavy and used too much horizontal space with a wide language `select`, a texty login/logout button, and a large logo. 
- The goal is to reduce visual noise and make the header more compact and consistent across widget variants.

### Description
- Replaced the language `<select>` with a compact DE/EN toggle button that shows the current language and switches on click in `src/components/ChatHeader.tsx`.
- Replaced the verbose `Login`/`Logout` label with a compact icon-like state to reduce text width and visual weight in `src/components/ChatHeader.tsx`.
- Introduced a shared `.header-pill-btn` style and tightened header spacing and logo height in `src/styles/classic.css`.
- Updated the landscape-specific override to target the new `.header-pill-btn` class in `src/styles/landscape.css` so styling remains consistent.

### Testing
- Ran `npm run build` to validate the change, which failed in this environment due to missing project dependencies/type declarations for React/TypeScript; this is a baseline environment issue not caused by these UI changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad2266d548324a696a36005581422)