### PR TITLE
Auto-Play TTS für Bot-Antworten im Voice-Modus

### DIFF
--- a/src/components/ChatBody.tsx
+++ b/src/components/ChatBody.tsx
@@ -17,6 +17,7 @@ interface ChatBodyProps {
   conversationId?: string | null;
   onRespinLastAnswer?: () => void;
   disableRespin?: boolean;
+  autoSpeakBotMessages?: boolean;
 }
 
 function FormSketch({ form }: { form?: InputRequest['form'] }) {
@@ -539,6 +540,7 @@ export const ChatBody: React.FC<ChatBodyProps> = ({
   conversationId,
   onRespinLastAnswer,
   disableRespin = false,
+  autoSpeakBotMessages = false,
 }) => {
   const bottomRef = useRef<HTMLDivElement>(null);
   const [isInfoViewOpen, setIsInfoViewOpen] = useState(false);
@@ -588,6 +590,7 @@ export const ChatBody: React.FC<ChatBodyProps> = ({
             onRespin={onRespinLastAnswer}
             disableRespin={disableRespin}
             onShowInfoView={() => setIsInfoViewOpen(true)}
+            autoSpeak={autoSpeakBotMessages && message.id === messages[messages.length - 1]?.id}
           />
         ) : (
           <UserMessage key={message.id} message={message} />

--- a/src/components/ChatWidget/ChatWidget.tsx
+++ b/src/components/ChatWidget/ChatWidget.tsx
@@ -264,6 +264,7 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ config, widgetId, onPlan
                   conversationId={conversationId}
                   onRespinLastAnswer={handleRespinLastAnswer}
                   disableRespin={isThinking}
+                  autoSpeakBotMessages={isLiveMode}
                 />
                 <ChatFooter
                   quickReplies={footerQuickReplies}
@@ -297,6 +298,7 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ config, widgetId, onPlan
                 conversationId={conversationId}
                 onRespinLastAnswer={handleRespinLastAnswer}
                 disableRespin={isThinking}
+                autoSpeakBotMessages={isLiveMode}
               />
               <ChatFooter
                 quickReplies={footerQuickReplies}

--- a/src/components/Message/BotMessage.tsx
+++ b/src/components/Message/BotMessage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import type { Message } from '../../types';
 import { renderMarkdown } from '../../utils/markdown';
 import { speakText, stopSpeaking } from '../../utils/speech';
@@ -11,6 +11,7 @@ interface BotMessageProps {
   onRespin?: () => void;
   disableRespin?: boolean;
   onShowInfoView?: () => void;
+  autoSpeak?: boolean;
 }
 
 const IconThumbUp = () => (
@@ -85,11 +86,24 @@ export const BotMessage: React.FC<BotMessageProps> = ({
   onRespin,
   disableRespin = false,
   onShowInfoView,
+  autoSpeak = false,
 }) => {
   const [thumbState, setThumbState] = useState<'up' | 'down' | null>(null);
   const [copied, setCopied] = useState(false);
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [showSources, setShowSources] = useState(false);
+
+  const hasAutoSpokenRef = useRef(false);
+
+  useEffect(() => {
+    if (!autoSpeak || hasAutoSpokenRef.current) return;
+
+    hasAutoSpokenRef.current = true;
+    setIsSpeaking(true);
+    speakText(message.text, {
+      onEnd: () => setIsSpeaking(false),
+    });
+  }, [autoSpeak, message.text]);
 
   const handleCopy = async () => {
     try {
@@ -105,7 +119,7 @@ export const BotMessage: React.FC<BotMessageProps> = ({
     setIsSpeaking((prev) => {
       const next = !prev;
       if (next) {
-        speakText(message.text);
+        speakText(message.text, { onEnd: () => setIsSpeaking(false) });
       } else {
         stopSpeaking();
       }


### PR DESCRIPTION
### Motivation
- Bot-Antworten sollen im aktivierten Voice‑Modus automatisch mit der integrierten TTS‑Stimme vorgelesen werden, damit Nutzer nicht jedes Mal den "Vorlesen"‑Button drücken müssen.

### Description
- Ergänzt optionales Prop `autoSpeak` in `BotMessage` und startet einmalig die Wiedergabe per `speakText(...)` für die eingehende Nachricht, wobei ein `hasAutoSpokenRef` erneutes Abspielen bei Re‑Renders verhindert.
- `ChatBody` erhält das Prop `autoSpeakBotMessages` und übergibt `autoSpeak` nur an die aktuellste Bot‑Nachricht (`message.id === messages[messages.length - 1]?.id`).
- `ChatWidget` leitet den Voice‑Moduszustand `isLiveMode` an `ChatBody` weiter (`autoSpeakBotMessages={isLiveMode}`) damit Auto‑TTS ausschließlich im Voice‑Modus aktiv ist.
- Bestehende manuelle „Vorlesen“‑Schaltfläche und ihr Verhalten bleiben unverändert; TTS beendet sich nach Ende via Callback (`onEnd`) und der Speak‑Status wird zurückgesetzt.

### Testing
- Versucht: `npm run build`; Ergebnis: fehlgeschlagen in dieser Umgebung wegen fehlender Projektabhängigkeiten/Typen (z.B. `react`/`react-dom`), weshalb der Build nicht vollständig ausgeführt werden konnte.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aa7d6debc8324a49df74c09aaaa3f)